### PR TITLE
Use CMake for ccache versions 4 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Make sure you have the required dependencies installed:
   - A C++ compiler
   - A C compiler
+  - CMake (when installing ccache version 4 or newer)
   - GNU make
   - curl
   - git

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Thanks goes to these wonderful people
   <tr>
     <td align="center"><a href="https://bsky.moe"><img src="https://avatars3.githubusercontent.com/u/38746192?v=4" width="100px;" alt=""/><br /><sub><b>BSKY</b></sub></a><br /><a href="https://github.com/asdf-community/asdf-ccache/commits?author=imbsky" title="Code">💻</a> <a href="https://github.com/asdf-community/asdf-ccache/commits?author=imbsky" title="Documentation">📖</a> <a href="#maintenance-imbsky" title="Maintenance">🚧</a> <a href="#infra-imbsky" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
     <td align="center"><a href="https://sasurau4.github.io/profile/"><img src="https://avatars3.githubusercontent.com/u/13580199?v=4" width="100px;" alt=""/><br /><sub><b>Daiki Ihara</b></sub></a><br /><a href="#infra-sasurau4" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a></td>
+    <td align="center"><a href="https://www.jwillikers.com"><img src="https://avatars1.githubusercontent.com/u/19399197?v=4" width="100px;" alt=""/><br /><sub><b>Jordan Williams</b></sub></a><br /><a href="https://github.com/asdf-community/asdf-ccache/commits?author=Jordan Williams" title="Code">💻</a> <a href="https://github.com/asdf-community/asdf-ccache/commits?author=Jordan Williams" title="Documentation">📖</a></td>
   </tr>
 </table>
 

--- a/bin/install
+++ b/bin/install
@@ -52,7 +52,7 @@ install_ccache() {
     else
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=yes .. >/dev/null || fail "Could not configure CMake"
+      cmake -DCMAKE_INSTALL_PREFIX="$install_path" -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=yes .. >/dev/null || fail "Could not configure CMake"
     fi
 
     echo "∗ Compiling..."

--- a/bin/install
+++ b/bin/install
@@ -47,7 +47,13 @@ install_ccache() {
     cd "$distination"
 
     echo "∗ Configuring..."
-    ./configure --prefix="$install_path" >/dev/null || fail "Could not configure"
+    if [[ "$version" =~ ^[0-3]\. ]]; then
+      ./configure --prefix="$install_path" >/dev/null || fail "Could not configure"
+    else
+      mkdir build
+      cd build
+      cmake -DCMAKE_BUILD_TYPE=Release .. >/dev/null || fail "Could not configure CMake"
+    fi
 
     echo "∗ Compiling..."
     make &>log.make || fail "Could not compile"

--- a/bin/install
+++ b/bin/install
@@ -52,7 +52,7 @@ install_ccache() {
     else
       mkdir build
       cd build
-      cmake -DCMAKE_BUILD_TYPE=Release .. >/dev/null || fail "Could not configure CMake"
+      cmake -DCMAKE_BUILD_TYPE=Release -DZSTD_FROM_INTERNET=yes .. >/dev/null || fail "Could not configure CMake"
     fi
 
     echo "∗ Compiling..."


### PR DESCRIPTION
Fixes #8 

Use GNU automake for versions 3 and earlier of ccache, but use CMake for versions 4 and newer.